### PR TITLE
Add get_version_info tool + CI workflow (v0.4.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: pytest (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package + test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install pytest pytest-asyncio
+
+      - name: Run unit tests (L2)
+        run: python -m pytest tests/test_tools.py -v
+
+      - name: Run security tests
+        run: python -m pytest tests/test_security.py -v
+
+  ci-all-green:
+    name: ci-all-green
+    needs: [test]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Verify required jobs all succeeded
+        run: |
+          if [[ "${{ needs.test.result }}" != "success" ]]; then
+            echo "FAIL: test matrix did not all succeed (result=${{ needs.test.result }})"
+            exit 1
+          fi
+          echo "All required CI jobs passed."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to `hamqth-mcp` are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.4.1] — 2026-05-16
+
+### Added
+- New tool `get_version_info` — returns `{service_name, service_version, spec_version}`
+  for fleet identity attestation. Tracks [IONIS-AI/ionis-devel#49](https://github.com/IONIS-AI/ionis-devel/issues/49).
+- `__spec_version__` pinned to `hamqth-com-v1`.
+- L2 unit tests HAMQTH-L2-046 through HAMQTH-L2-050.
+- `.github/workflows/ci.yml` — PR-gating CI (py3.10-3.13 matrix).
+
+### Changed
+- `__init__.py` modernized to fleet pattern (`Final` types).
+
+## [0.4.0] — Previous release
+- See git history for changes prior to the changelog being introduced.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ pip install hamqth-mcp
 | `hamqth_dx_spots` | No | Live DX cluster spots — filter by band and/or callsign |
 | `hamqth_rbn` | No | Reverse Beacon Network decodes — filter by band, mode, continent, callsign |
 | `hamqth_verify_qso` | No | Verify a QSO via HamQTH SAVP protocol |
+| `get_version_info` | No | Service version + upstream HamQTH API version (fleet identity attestation) |
 
 ## Quick Start
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hamqth-mcp"
-version = "0.4.0"
+version = "0.4.1"
 description = "MCP server for HamQTH.com — callsign lookup, DX spots, RBN, QSO verification"
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}

--- a/src/hamqth_mcp/__init__.py
+++ b/src/hamqth_mcp/__init__.py
@@ -2,9 +2,18 @@
 
 from __future__ import annotations
 
-try:
-    from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
+from typing import Final
 
-    __version__ = version("hamqth-mcp")
-except Exception:
-    __version__ = "0.0.0-dev"
+try:
+    _pkg_version = version("hamqth-mcp")
+except PackageNotFoundError:  # local dev / editable installs without dist metadata
+    _pkg_version = "0.0.0-dev"
+
+__version__: Final[str] = _pkg_version
+
+# Upstream data spec the server is bound to. Pinned to the HamQTH.com API
+# contract revision we consume — bump this when HamQTH publishes a new
+# API contract. Reported by the get_version_info tool so agents can
+# detect fleet drift without going outside the MCP protocol.
+__spec_version__: Final[str] = "hamqth-com-v1"

--- a/src/hamqth_mcp/server.py
+++ b/src/hamqth_mcp/server.py
@@ -10,7 +10,7 @@ from fastmcp import FastMCP
 
 from qso_graph_auth.identity import PersonaManager
 
-from . import __version__
+from . import __spec_version__, __version__
 from .client import HamQTHClient
 
 mcp = FastMCP(
@@ -57,6 +57,31 @@ def _public() -> HamQTHClient:
 # ---------------------------------------------------------------------------
 # Tools
 # ---------------------------------------------------------------------------
+
+
+def _version_info_payload() -> dict[str, Any]:
+    """Build the version info envelope. Pulled into a helper so tests can
+    call it directly without going through the FastMCP wrapper."""
+    return {
+        "service_name": "hamqth-mcp",
+        "service_version": __version__,
+        "spec_version": __spec_version__,
+    }
+
+
+@mcp.tool()
+def get_version_info() -> dict[str, Any]:
+    """Get hamqth-mcp service version and upstream HamQTH API version.
+
+    Returns the running PyPI version of hamqth-mcp and the HamQTH.com API
+    contract in use. Use this to confirm fleet alignment across MCP
+    deployments — agents can compare service_version and spec_version
+    across servers to detect drift without going outside the MCP protocol.
+
+    Returns:
+        service_name, service_version (PyPI), and spec_version (HamQTH API).
+    """
+    return _version_info_payload()
 
 
 @mcp.tool()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -290,3 +290,48 @@ class TestClientDirect:
         """HAMQTH-L2-045: Direct client verify returns dict."""
         result = client.verify_qso("KI7MT", "OK2CQR", "20260305", "20M")
         assert result["result"] == "Y"
+
+
+# ---------------------------------------------------------------------------
+# HAMQTH-L2-046..050: get_version_info — fleet identity attestation
+# ---------------------------------------------------------------------------
+
+
+class TestGetVersionInfo:
+    """Tracks IONIS-AI/ionis-devel#49 — fleet get_version_info convention."""
+
+    def test_returns_service_name(self):
+        """HAMQTH-L2-046: payload includes service_name = 'hamqth-mcp'."""
+        from hamqth_mcp.server import _version_info_payload
+
+        assert _version_info_payload()["service_name"] == "hamqth-mcp"
+
+    def test_returns_service_version(self):
+        """HAMQTH-L2-047: service_version matches package __version__."""
+        from hamqth_mcp import __version__
+        from hamqth_mcp.server import _version_info_payload
+
+        assert _version_info_payload()["service_version"] == __version__
+
+    def test_returns_spec_version(self):
+        """HAMQTH-L2-048: spec_version pins the HamQTH API contract."""
+        from hamqth_mcp.server import _version_info_payload
+
+        assert _version_info_payload()["spec_version"] == "hamqth-com-v1"
+
+    def test_payload_keys_are_required_set(self):
+        """HAMQTH-L2-049: payload has the required keys (no extras yet)."""
+        from hamqth_mcp.server import _version_info_payload
+
+        result = _version_info_payload()
+        required = {"service_name", "service_version", "spec_version"}
+        assert required.issubset(set(result.keys()))
+
+    def test_all_values_are_strings(self):
+        """HAMQTH-L2-050: all returned values are strings (JSON-safe envelope)."""
+        from hamqth_mcp.server import _version_info_payload
+
+        result = _version_info_payload()
+        for k in ("service_name", "service_version", "spec_version"):
+            assert isinstance(result[k], str), f"{k} should be str, got {type(result[k])}"
+            assert result[k], f"{k} should be non-empty"


### PR DESCRIPTION
Fleet rollout per [IONIS-AI/ionis-devel#49](https://github.com/IONIS-AI/ionis-devel/issues/49). Tenth and final public server. Envelope: `{service_name, service_version, spec_version=hamqth-com-v1}`. 5 new tests (HAMQTH-L2-046..050).